### PR TITLE
String compared to integer in code-creation

### DIFF
--- a/lib/core-events/tick.js
+++ b/lib/core-events/tick.js
@@ -26,7 +26,7 @@ function tick (state) {
       stack.unshift(extCbOrTos)
     } else {
       stack.unshift(pc)
-      const ix = sorted.lte(state.addresses, extCbOrTos)
+      const ix = sorted.lte(state.addresses, parseInt(extCbOrTos, 16))
       if (ix > -1) {
         const match = state.code[state.addresses[ix]]
         const isJsFunction = match[FUNC] && match.cs


### PR DESCRIPTION
When running the tests on a fresh clone/install, I get the following failure:
```sh
proffer git/master
 ❯ npm test

> proffer@1.0.0 test /Users/mattcan/source/proffer
> tap test/index.js && standard

 FAIL  test/index.js
 ✖ Cannot read property 'name' of undefined

  test/index.js
  715 |     is(tick.stack[0].name, '0x3000000010', 'first address in stack')
  716 |     is(tick.stack[1].name, '0x1007269a9', 'pc just under top of stack')
> 717 |     is(tick.stack[2].name, 'Topper', 'top of stack resolved function at top of stack')
      | ---------------------^
  718 |     end()
  719 |   })
  720 |

  test: tick adds top of stack address to stack (above pc) when top of stack
    address references a JS function
  stack: >
    Pumpify.stream.once (test/index.js:717:22)

    Pumpify.Readable.read (node_modules/duplexify/node_modules/readable-stream/lib/_stream_readable.js:483:26)

    flow (node_modules/duplexify/node_modules/readable-stream/lib/_stream_readable.js:939:34)

    resume_ (node_modules/duplexify/node_modules/readable-stream/lib/_stream_readable.js:918:3)
  type: TypeError
  tapCaught: uncaughtException
```

This seems to be something that worked initially but because of a change in the default comparison on sorted-array-functions library, it surfaced the incorrect comparison of an array of integers and a string. The life changing commit is here:
https://github.com/mafintosh/sorted-array-functions/commit/07672c2b272366cb2e873ef4474298d3c192e792.

The `master` branch works with sorted-array-functions@1.2.0 (pinned) but failed at 1.3.0.

The fix changes the `extCbOrTos` value from a string to an integer. I chose not to save the result of the `parseInt` for two reasons:
  * a little bit into the code, every address in the stack is run through `parseInt` so trying to avoid weirdness
  * the string result is ultimately sent to the callback function